### PR TITLE
Index search

### DIFF
--- a/src/main/java/com/beligum/blocks/index/ifaces/IndexSearchRequest.java
+++ b/src/main/java/com/beligum/blocks/index/ifaces/IndexSearchRequest.java
@@ -119,11 +119,20 @@ public interface IndexSearchRequest extends Serializable
     IndexSearchRequest filter(IndexEntryField field, String value, FilterBoolean filterBoolean, Option... options);
 
     /**
-     //FIXME document
+     * Adds a filter that allows a blockjoin. This means the parent object is  retrieved base on properties  defined on it's children.
+     * @param standalone: if true, the blockjoin will  be added to the query as a filter. If false, the blockjoin will be appended to the query proper.
+     * @param filterValues: one or more filterValues to filter the children of which the parent(s) will be retrieved.
+     * @param filterProperty: the property that will be filtered
+     * @param rdfClass: the parent class that will  be the result  of the  blockjoin
      */
     IndexSearchRequest blockjoinToParent(RdfClass rdfClass, RdfProperty filterProperty, boolean standalone, String... filterValues) throws IOException;
 
-
+    /**
+     * This will return a 'bubble up' graph from the 'lowest' dependency within the
+     * @param rdfClasses: these classes need  to  have  a child-parent dependency on eachOther. The lowest class comes  first.
+     * @param returnRoot: return the lowest level itself. Should usually be true.
+     * @param leafNodesOnly: only return the outer results of the graph traversal,  ignore the  others. Should  usually be false.
+     */
     IndexSearchRequest joinedGraphTraversalQuery(boolean returnRoot, boolean leafNodesOnly, RdfClass... rdfClasses);
     /**
      * Adds a filter that only selects entries that have the value for the specified property.

--- a/src/main/java/com/beligum/blocks/index/ifaces/IndexSearchRequest.java
+++ b/src/main/java/com/beligum/blocks/index/ifaces/IndexSearchRequest.java
@@ -119,6 +119,13 @@ public interface IndexSearchRequest extends Serializable
     IndexSearchRequest filter(IndexEntryField field, String value, FilterBoolean filterBoolean, Option... options);
 
     /**
+     //FIXME document
+     */
+    IndexSearchRequest blockjoinToParent(RdfClass rdfClass, RdfProperty filterProperty, boolean standalone, String... filterValues) throws IOException;
+
+
+    IndexSearchRequest joinedGraphTraversalQuery(boolean returnRoot, boolean leafNodesOnly, RdfClass... rdfClasses);
+    /**
      * Adds a filter that only selects entries that have the value for the specified property.
      * Note that the way this value is interpreted can be tweaked using the options
      * The boolean configures how this filter is linked to previously added filters.

--- a/src/main/java/com/beligum/blocks/index/solr/SolrIndexSearchRequest.java
+++ b/src/main/java/com/beligum/blocks/index/solr/SolrIndexSearchRequest.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.parser.QueryParser;
-import org.apache.solr.search.SolrQueryParser;
 
 import java.io.IOException;
 import java.util.*;

--- a/src/main/java/com/beligum/blocks/index/solr/SolrIndexSearchRequest.java
+++ b/src/main/java/com/beligum/blocks/index/solr/SolrIndexSearchRequest.java
@@ -2,6 +2,7 @@ package com.beligum.blocks.index.solr;
 
 import com.beligum.base.server.R;
 import com.beligum.base.utils.Logger;
+import com.beligum.blocks.config.WidgetType;
 import com.beligum.blocks.index.entries.JsonPageIndexEntry;
 import com.beligum.blocks.index.ifaces.*;
 import com.beligum.blocks.index.request.AbstractIndexSearchRequest;
@@ -9,6 +10,7 @@ import com.beligum.blocks.rdf.ifaces.RdfClass;
 import com.beligum.blocks.rdf.ifaces.RdfProperty;
 import com.google.common.collect.Iterables;
 import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.parser.QueryParser;
 import org.apache.solr.search.SolrQueryParser;
@@ -61,6 +63,8 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
     private StringBuilder queryBuilder;
     private StringBuilder filterQueryBuilder;
     private String languageGroupFilter;
+    private Map<String, List<String>> customParams;
+
 
     //-----CONSTRUCTORS-----
     public SolrIndexSearchRequest(IndexConnection indexConnection)
@@ -69,6 +73,8 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
 
         this.queryBuilder = new StringBuilder();
         this.filterQueryBuilder = new StringBuilder();
+        this.customParams = new HashMap<>();
+
     }
 
     //-----PUBLIC METHODS-----
@@ -94,6 +100,57 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
 
         return this;
     }
+
+    @Override
+    public IndexSearchRequest blockjoinToParent(RdfClass rdfClass, RdfProperty filterProperty, boolean standalone, String... filterValues) throws IOException {
+        if (filterValues != null && filterValues.length > 0) {
+            List<String> queries = buildBlockjoins(rdfClass, filterProperty, filterValues);
+            if (queries != null && queries.size() > 0) {
+                if(!standalone){
+                    //check if param already exists
+                    List<String> params = this.customParams.get(rdfClass.getName());
+                    if(params == null){
+                        params = new ArrayList<>();
+                    }
+                    params.addAll(queries);
+                    this.customParams.put(rdfClass.getName(),params);
+                }else{
+                    //add as a filterQuery
+                    List<String> params = this.customParams.get("fq");
+                    if(params == null){
+                        params = new ArrayList<>();
+                    }
+                    params.addAll(queries);
+                    this.customParams.put("fq", params);
+                }
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public IndexSearchRequest joinedGraphTraversalQuery(boolean returnRoot, boolean leafNodesOnly, RdfClass... rdfClasses) {
+        if(this.queryBuilder.length()!=0){
+            throw new UnsupportedOperationException("Can not combine this query with another query");
+        }
+        if(checkDependency(rdfClasses)){
+            //always  start with the lowest class
+            //this one will  always be needed
+            for(int i = 0; i <rdfClasses.length; i++){
+                if(i==0){
+                    this.queryBuilder.append("{!graph from=uri to=parentUri returnRoot=");
+                    this.queryBuilder.append(returnRoot);
+                    this.queryBuilder.append(" leafNodesOnly=");
+                    this.queryBuilder.append(leafNodesOnly);
+                    this.queryBuilder.append("}{!filters param=$" + rdfClasses[i].getName() + "}");
+                }else{
+                    this.queryBuilder.append("{!join from=uri to=parentUri}{!filters param=$" + rdfClasses[i].getName() + "}");
+                }
+            }
+        }
+        return this;
+    }
+
     @Override
     public IndexSearchRequest filter(RdfProperty property, String value, FilterBoolean filterBoolean, Option... options)
     {
@@ -194,6 +251,14 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
         }
         else {
             retVal.setFilterQueries();
+        }
+        //add custom parameters
+        if(this.customParams.keySet().size()>0){
+            for(String key : this.customParams.keySet()) {
+                if(!key.equals("fq")){
+                    retVal.setParam(key, this.customParams.get(key).toArray(new String[this.customParams.get(key).size()]));
+                }
+            }
         }
 
         // the above call overwrites all filters, so make sure to add the language grouping filter
@@ -331,8 +396,8 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
     private String escapeDefault(String value)
     {
         // by default, we decided not to escape the raw query value to allow the API caller to use all bells and whistles she wants
-        //return this.escapeTerm(value);
-        return value;
+        return this.escapeTerm(value);
+//        return value;
     }
     private String escapeTerm(String term)
     {
@@ -355,7 +420,124 @@ public class SolrIndexSearchRequest extends AbstractIndexSearchRequest
 
         return sb.toString();
     }
+    private boolean checkDependency(RdfClass... rdfClasses){
+        if(rdfClasses.length > 1){
+            //check parent-childl relationship
+            for(int i = 1; i<rdfClasses.length;i++){
+                boolean found = false;
+                //start with  second class. Has to be a child of the first, etc.
+                Iterator<RdfProperty> rdfPropertyIterator = rdfClasses[i].getProperties().iterator();
+                while(rdfPropertyIterator.hasNext()){
+                    RdfProperty rdfProperty = rdfPropertyIterator.next();
+                    if(rdfProperty.getDataType().equals(rdfClasses[i-1])){
+                        found = true;
+                    }
+                }
+                if(!found){
+                    Logger.error(rdfClasses[i].getCurie().toString()+ " is does not have  a dependency on "+rdfClasses[i-1].getCurie().toString()+". Can't continue");
+                }
+            }
+        }
+        return true;
+    }
 
+    private List<String> buildBlockjoins(RdfClass rdfClass, RdfProperty filterProperty, String... filterValues) throws IOException {
+        String defaultFilterVariable = ResourceIndexEntry.Type.DEFAULT.toString();
+        String resourceTypeFilterKey = ResourceIndexEntry.resourceTypeField.getName();
+        String defaultFilterQuery = resourceTypeFilterKey + ":" + defaultFilterVariable;
+
+        String queryPrefix = "{!parent which=typeOf:";
+        String queryClosingCurlyBracket = "}";
+        String queryClosingParenthesis = ")";
+        String queryOpeningParenthesis = "(";
+
+        String column = ":";
+        String space = " ";
+        String plus = "+";
+        List<String> queries = new ArrayList<>();
+
+        if (filterValues != null && filterValues.length > 0) {
+            String queryString;
+            //OPTION 1: number. Allows for range as [number - number]
+            if (filterProperty.getWidgetType().equals(WidgetType.Number)) {
+                //just a single filterValue allowed
+                if (filterValues.length > 1) {
+                    throw new IOException("just a single filter value allowed for " + WidgetType.Number);
+                }
+                String filterValue = filterValues[0].replaceAll(space, "");
+                filterValue = filterValue.replace("-", " TO ");
+                filterValue = "[" + filterValue + "]";
+                queryString = queryPrefix + QueryParser.escape(rdfClass.getCurie().toString()) + queryClosingCurlyBracket + QueryParser.escape(filterProperty.getCurie().toString()) + column + filterValue;
+                queries.add(queryString);
+            } else if (filterProperty.getWidgetType().equals(WidgetType.Resource)) {
+                if (filterValues.length > 1) {
+                    throw new IOException("just a single filter value allowed for " + WidgetType.Number);
+                }
+                queryString =
+                        queryPrefix + QueryParser.escape(rdfClass.getCurie().toString()) + queryClosingCurlyBracket + queryOpeningParenthesis + plus + ResourceIndexEntry.resourceField.getName() + column +
+                                QueryParser.escape(filterValues[0]);
+                String addedString = " -" + defaultFilterQuery;
+                queryString = queryString + addedString + queryClosingParenthesis;
+                queries.add(queryString);
+            } else if (filterProperty.getWidgetType().equals(WidgetType.Object)) {
+                if (filterProperty.getDataType().getMainProperty() != null &&
+                        filterProperty.getDataType().getMainProperty().getDataType() != null &&
+                        filterProperty.getDataType().getMainProperty().getDataType().getEndpoint() != null &&
+                        filterProperty.getDataType().getMainProperty().getDataType().getEndpoint().isExternal()) {
+                    //external  endpoint (e.g.wikidata)
+                    queryString = queryPrefix + QueryParser.escape(rdfClass.getCurie().toString()) + queryClosingCurlyBracket;
+
+                    String tempString = queryOpeningParenthesis + plus + QueryParser.escape(ResourceIndexEntry.resourceField.getName()) + column + QueryParser.escape(filterValues[0]);
+                    queryString = queryString + tempString;
+                    //if we are  looking up  more than  one filterValue, iterate and add  them.
+                    if (filterValues.length > 1) {
+                        //obviously, ignore  the  first
+                        for (int i = 1; i < filterValues.length; i++) {
+                            String extraValue = filterValues[i];
+                            if (!StringUtils.isEmpty(extraValue)) {
+                                String typePropertyString =
+                                        space + plus + queryPrefix + QueryParser.escape(filterProperty.getDataType().getCurie().toString()) + queryClosingCurlyBracket + plus +
+                                                ResourceIndexEntry.resourceField.getName() + column + QueryParser.escape(extraValue);
+                                queryString = queryString + typePropertyString;
+                            }
+                        }
+                    }
+                    queryString = queryString + queryClosingParenthesis;
+                    queries.add(queryString);
+                } else if (filterProperty.getDataType().getMainProperty().getWidgetType().equals(WidgetType.Resource)) {
+                    String basicString = "+(" + queryPrefix + QueryParser.escape(rdfClass.getCurie().toString()) + queryClosingCurlyBracket;
+                    String resourceString = plus + QueryParser.escape(ResourceIndexEntry.resourceField.getName()) + column + QueryParser.escape(filterValues[0]);
+                    queryString = basicString + resourceString + queryClosingParenthesis;
+                    if (filterValues.length > 1) {
+                        //obviously, ignore  the  first
+                        for (int i = 1; i < filterValues.length; i++) {
+                            String extraValue = filterValues[i];
+                            String typePropertyString = plus + ResourceIndexEntry.resourceField.getName() + column + QueryParser.escape(extraValue);
+                            typePropertyString = basicString + typePropertyString;
+                            queryString = queryString + space + typePropertyString + queryClosingParenthesis;
+                        }
+                    }
+                    queries.add(queryString);
+                } else {
+                    queryString =
+                            queryPrefix + QueryParser.escape(rdfClass.getCurie().toString()) + queryClosingCurlyBracket + plus +
+                                    QueryParser.escape(filterProperty.getDataType().getMainProperty().getCurie().toString()) + column + QueryParser.escape(filterValues[0]);
+                    if (filterValues.length > 1) {
+                        //obviously, ignore  the  first
+                        for (int i = 1; i < filterValues.length; i++) {
+                            String extraValue = filterValues[i];
+                            String typePropertyString =
+                                    space + plus + queryPrefix + QueryParser.escape(filterProperty.getDataType().getCurie().toString()) + queryClosingCurlyBracket + plus +
+                                            ResourceIndexEntry.resourceField.getName() + column + QueryParser.escape(extraValue);
+                            queryString = queryString + typePropertyString;
+                        }
+                    }
+                    queries.add(queryString);
+                }
+            }
+        }
+        return queries;
+    }
     //-----MGMT METHODS-----
     @Override
     public String toString()

--- a/src/main/java/com/beligum/blocks/index/solr/SolrPageIndexConnection.java
+++ b/src/main/java/com/beligum/blocks/index/solr/SolrPageIndexConnection.java
@@ -31,6 +31,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.handler.UpdateRequestHandler;
 import org.apache.solr.servlet.SolrRequestParsers;
@@ -276,6 +277,22 @@ public class SolrPageIndexConnection extends AbstractIndexConnection implements 
         else {
             throw new IOException("Encountered unsupported query format; " + format);
         }
+
+        return retVal;
+    }
+    public IndexSearchResult search(SolrParams params) throws IOException
+    {
+        this.assertActive();
+
+        IndexSearchResult retVal = null;
+        try {
+            retVal = new SolrIndexSearchResult(this.solrClient.query(params));
+        }
+        catch (SolrServerException e) {
+            throw new IOException("Error while executing a Solr search; " + params, e);
+        }
+
+
 
         return retVal;
     }

--- a/src/main/java/com/beligum/blocks/index/sparql/SparqlIndexSearchRequest.java
+++ b/src/main/java/com/beligum/blocks/index/sparql/SparqlIndexSearchRequest.java
@@ -84,6 +84,17 @@ public class SparqlIndexSearchRequest extends AbstractIndexSearchRequest
     {
         throw new UnsupportedOperationException("Internal index fields are not supported in the SPARQL query builder; " + field);
     }
+
+    @Override
+    public IndexSearchRequest blockjoinToParent(RdfClass rdfClass, RdfProperty filterProperty, boolean standalone, String... filterValues) throws IOException {
+        throw new UnsupportedOperationException("Block joins are not supported in the SPARQL query builder" );
+    }
+
+    @Override
+    public IndexSearchRequest joinedGraphTraversalQuery(boolean returnRoot, boolean leafNodesOnly, RdfClass... rdfClasses) {
+        throw new UnsupportedOperationException("Joined Graph traversals are not supported in the SPARQL query builder" );
+    }
+
     @Override
     public IndexSearchRequest filter(RdfProperty property, String value, FilterBoolean filterBoolean, Option... options)
     {

--- a/src/main/java/com/beligum/blocks/index/sparql/SparqlIndexSelectResult.java
+++ b/src/main/java/com/beligum/blocks/index/sparql/SparqlIndexSelectResult.java
@@ -16,6 +16,8 @@ public class SparqlIndexSelectResult extends AbstractIndexSearchResult<SparqlSel
 
     //-----VARIABLES-----
     private List<BindingSet> selectResult;
+    private List<String> bindingNames;
+
 
     //-----CONSTRUCTORS-----
     public SparqlIndexSelectResult(TupleQueryResult result, long elapsedTime)
@@ -24,6 +26,9 @@ public class SparqlIndexSelectResult extends AbstractIndexSearchResult<SparqlSel
 
         // we "materialize" the query at once, so we have it's size and can close it properly
         this.selectResult = QueryResults.asList(result);
+        if(result != null){
+            this.bindingNames = result.getBindingNames();
+        }
     }
 
     //-----PUBLIC METHODS-----
@@ -41,6 +46,10 @@ public class SparqlIndexSelectResult extends AbstractIndexSearchResult<SparqlSel
     public java.util.Iterator<SparqlSelectIndexEntry> iterator()
     {
         return new SparqlSelectIterator(this.selectResult);
+    }
+
+    public List<String>getBindingNames(){
+        return this.bindingNames;
     }
 
     //-----PROTECTED METHODS-----

--- a/src/main/java/com/beligum/blocks/rdf/ontologies/endpoints/EnumQueryEndpoint.java
+++ b/src/main/java/com/beligum/blocks/rdf/ontologies/endpoints/EnumQueryEndpoint.java
@@ -149,7 +149,7 @@ public class EnumQueryEndpoint implements RdfEndpoint
 
     //-----PROTECTED METHODS-----
     //allows us to override this in subclasses
-    protected Map<String, EnumSuggestion> getSuggestions()
+    public Map<String, EnumSuggestion> getSuggestions()
     {
         return this.suggestions;
     }

--- a/src/main/java/com/beligum/blocks/rdf/ontologies/endpoints/LanguageEnumQueryEndpoint.java
+++ b/src/main/java/com/beligum/blocks/rdf/ontologies/endpoints/LanguageEnumQueryEndpoint.java
@@ -49,7 +49,7 @@ public class LanguageEnumQueryEndpoint extends EnumQueryEndpoint
 
     //-----PROTECTED METHODS-----
     @Override
-    protected Map<String, EnumSuggestion> getSuggestions()
+    public Map<String, EnumSuggestion> getSuggestions()
     {
         //we can make the languageSuggestions static and save some space because it won't change across instances anyway
         if (languageSuggestions == null) {


### PR DESCRIPTION
Allowed blockjoinToParent and joinedGraphTraversalQuery
This is not implemented  in SparqlIndexSearchRequest
SparqlIndexSearchRequest: allowing access to the bindingNames retrieved from the result.